### PR TITLE
Updating some wording in the README and main_terminal.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ this repo contains the logic for our CLI, powered by [Terminalwire](https://term
 
 code inside `lib/` is not intended to run independently of the core TRMNL web server. it does, however, showcase design choices and hierarchy of available CRUD behaviors.
 
-we open feedback and contributions to the following areas:
+we are open to feedback and contributions to the following areas:
 
 - attributes and formatting via `list` style commands, ex `trmnl plugins ls`
 - CLI-only "go" actions that commit write operations, ex `trmnl go shopping_list <item>`

--- a/lib/main_terminal.rb
+++ b/lib/main_terminal.rb
@@ -1,7 +1,7 @@
 class MainTerminal < ApplicationTerminal
   VERSION = '0.0.1'.freeze
 
-  desc "login", "Login to your account"
+  desc "login", "Log in to your account"
   def login
     print "Email: "
     email = gets.chomp
@@ -49,7 +49,7 @@ class MainTerminal < ApplicationTerminal
     puts VERSION
   end
 
-  desc "logout", "Logout of your account"
+  desc "logout", "Log out of your account"
   def logout
     session.reset
     puts "Successfully logged out."


### PR DESCRIPTION
Was just looking through the CLI code and noticed that 'Login' and 'Logout' were used incorrectly. Also some missing words to a sentence in the README